### PR TITLE
Add bespoerp alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
     <a href="https://frappe.io/erpnext">
-	<img src="./erpnext/public/images/v16/erpnext.svg" alt="ERPNext Logo" height="80px" width="80xp"/>
+        <img src="./erpnext/public/images/v16/erpnext.svg" alt="Bespoerp Logo" height="80px" width="80xp"/>
     </a>
-    <h2>ERPNext</h2>
+    <h2>Bespoerp</h2>
     <p align="center">
         <p>Powerful, Intuitive and Open-Source ERP</p>
     </p>
 
-[![Learn on Frappe School](https://img.shields.io/badge/Frappe%20School-Learn%20ERPNext-blue?style=flat-square)](https://frappe.school)<br><br>
+[![Learn on Frappe School](https://img.shields.io/badge/Frappe%20School-Learn%20Bespoerp-blue?style=flat-square)](https://frappe.school)<br><br>
 [![CI](https://github.com/frappe/erpnext/actions/workflows/server-tests-mariadb.yml/badge.svg?event=schedule)](https://github.com/frappe/erpnext/actions/workflows/server-tests-mariadb.yml)
 [![docker pulls](https://img.shields.io/docker/pulls/frappe/erpnext-worker.svg)](https://hub.docker.com/r/frappe/erpnext-worker)
 
@@ -25,13 +25,13 @@
 	<a href="https://docs.frappe.io/erpnext/">Documentation</a>
 </div>
 
-## ERPNext
+## Bespoerp
 
 100% Open-Source ERP system to help you run your business.
 
 ### Motivation
 
-Running a business is a complex task - handling invoices, tracking stock, managing personnel and even more ad-hoc activities. In a market where software is sold separately to manage each of these tasks, ERPNext does all of the above and more, for free.
+Running a business is a complex task - handling invoices, tracking stock, managing personnel and even more ad-hoc activities. In a market where software is sold separately to manage each of these tasks, Bespoerp does all of the above and more, for free.
 
 ### Key Features
 
@@ -100,7 +100,7 @@ See [Frappe Docker](https://github.com/frappe/frappe_docker?tab=readme-ov-file#t
 
 The Easy Way: our install script for bench will install all dependencies (e.g. MariaDB). See https://github.com/frappe/bench for more details.
 
-New passwords will be created for the ERPNext "Administrator" user, the MariaDB root user, and the frappe user (the script displays the passwords and saves them to ~/frappe_passwords.txt).
+New passwords will be created for the Bespoerp "Administrator" user, the MariaDB root user, and the frappe user (the script displays the passwords and saves them to ~/frappe_passwords.txt).
 
 
 ### Local
@@ -115,25 +115,25 @@ To setup the repository locally follow the steps mentioned below:
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site
-   bench new-site erpnext.localhost
+   bench new-site bespoerp.localhost
    ```
 
-3. Get the ERPNext app and install it
+3. Get the Bespoerp app and install it
    ```
-   # Get the ERPNext app
+   # Get the Bespoerp app
    bench get-app https://github.com/frappe/erpnext
 
    # Install the app
-   bench --site erpnext.localhost install-app erpnext
+   bench --site erpnext.localhost install-app bespoerp
    ```
 
 4. Open the URL `http://erpnext.localhost:8000/app` in your browser, you should see the app running
 
 ## Learning and community
 
-1. [Frappe School](https://school.frappe.io) - Learn Frappe Framework and ERPNext from the various courses by the maintainers or from the community.
-2. [Official documentation](https://docs.erpnext.com/) - Extensive documentation for ERPNext.
-3. [Discussion Forum](https://discuss.erpnext.com/) - Engage with community of ERPNext users and service providers.
+1. [Frappe School](https://school.frappe.io) - Learn Frappe Framework and Bespoerp from the various courses by the maintainers or from the community.
+2. [Official documentation](https://docs.erpnext.com/) - Extensive documentation for Bespoerp.
+3. [Discussion Forum](https://discuss.erpnext.com/) - Engage with community of Bespoerp users and service providers.
 4. [Telegram Group](https://erpnext_public.t.me) - Get instant help from huge community of users.
 
 

--- a/bespoerp/__init__.py
+++ b/bespoerp/__init__.py
@@ -1,0 +1,1 @@
+from erpnext import *


### PR DESCRIPTION
## Summary
- replace ERPNext brand name in README with Bespoerp
- add simple bespoerp package alias

## Testing
- `pytest -k nothing -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_685819440468832cb2c1b6a01f1f195c