### PR TITLE
⚡ Bolt: Optimize get_stock_value_on N+1 queries

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -78,8 +78,21 @@ def get_stock_value_on(
 			warehouses = [warehouses]
 
 		warehouses = set(warehouses)
-		for wh in list(warehouses):
-			if frappe.db.get_value("Warehouse", wh, "is_group"):
+
+		# Optimization: Bulk fetch is_group status to avoid N+1 queries
+		warehouse_list = list(warehouses)
+		is_group_map = {}
+		if warehouse_list:
+			records = frappe.db.get_all(
+				"Warehouse",
+				filters={"name": ["in", warehouse_list]},
+				fields=["name", "is_group"],
+			)
+			for d in records:
+				is_group_map[d["name"]] = d["is_group"]
+
+		for wh in warehouse_list:
+			if is_group_map.get(wh):
 				warehouses.update(get_child_warehouses(wh))
 
 		query = query.where(sle.warehouse.isin(warehouses))


### PR DESCRIPTION
💡 **What**: Optimized `get_stock_value_on` in `erpnext/stock/utils.py` by fetching warehouse group status in bulk instead of inside a loop.

🎯 **Why**: The original implementation performed a database query (`frappe.db.get_value`) for each warehouse in the input list to check if it's a group. This caused an N+1 query problem, which is inefficient when dealing with many warehouses (e.g., in reports).

📊 **Impact**:
- Reduces the number of queries for `is_group` check from `N` to `1` (where N is the number of warehouses).
- Improves performance of stock value calculations and reports that use this utility function.

🔬 **Measurement**:
- Verified using a reproduction script that mocked `frappe.db` and counted queries.
- Original logic: 50 queries for 50 warehouses.
- Optimized logic: 1 query for 50 warehouses.

---
*PR created automatically by Jules for task [14264367046669701304](https://jules.google.com/task/14264367046669701304) started by @nathanabay*